### PR TITLE
Add automatic word diff insertion into MongoDB

### DIFF
--- a/data-scripts/diff-urls.js
+++ b/data-scripts/diff-urls.js
@@ -1,5 +1,5 @@
 db.events.aggregate([
-        {$match: {"type": "PullRequestEvent"}},
+        {$match: {"type": "PullRequestEvent", "word_diff": {$exists: false}}},
         {$project: {"diff_url": "$payload.pull_request.diff_url"}},
         {$limit: 50}
     ])

--- a/data-scripts/download-and-convert-diffs.sh
+++ b/data-scripts/download-and-convert-diffs.sh
@@ -3,15 +3,16 @@
 cd "$(dirname $0)"
 source utils.sh
 
+# The maximum number of concurrent tasks to run at a time.
+RATE_LIMIT=10
+
+counter=1
 while read line; do
     args=$(jq .id,.diff_url <<<$line | tr '"' ' ')
     id=$(awk '{ print $1 }' <<<$args)
-    if [ -f "data/$id.diff" ]; then
-        error "Skipping already downloaded diff for ID: $id"
-        continue
-    fi
-    success "Beginning processing on ID: $id"
+    success "[$counter] Beginning processing on ID: $id"
     diff_url=$(awk '{ print $2 }' <<<$args)
-    wget -O - "$diff_url" | node line-to-word-diff/index.js > "data/$id.diff"
+    rate_limit "$RATE_LIMIT" wget --no-verbose --output-document - "$diff_url" \| node line-to-word-diff/index.js "$id"
+    counter=$(($counter + 1))
 done
-
+wait

--- a/data-scripts/download-and-convert-diffs.sh
+++ b/data-scripts/download-and-convert-diffs.sh
@@ -12,7 +12,10 @@ while read line; do
     id=$(awk '{ print $1 }' <<<$args)
     success "[$counter] Beginning processing on ID: $id"
     diff_url=$(awk '{ print $2 }' <<<$args)
-    rate_limit "$RATE_LIMIT" wget --no-verbose --output-document - "$diff_url" \| node line-to-word-diff/index.js "$id"
+    rate_limit "$RATE_LIMIT" \
+        wget --no-verbose --output-document - "$diff_url" \| \
+        awk '"length($0) < 1000"' \| \
+        node line-to-word-diff/index.js "$id"
     counter=$(($counter + 1))
 done
 wait

--- a/data-scripts/line-to-word-diff/index.js
+++ b/data-scripts/line-to-word-diff/index.js
@@ -1,14 +1,54 @@
+#!/usr/bin/env node
+
+const async = require('asyncawait/async');
+const await = require('asyncawait/await');
 const diffLineToWord = require('diff-linetoword');
 const getStdin = require('get-stdin');
 const JsDiff = require('diff');
+const mongodb = require('mongodb');
+const MongoClient = mongodb.MongoClient;
+const ObjectId = mongodb.ObjectId;
 
-getStdin().then(function(line_diff) {
-    if(line_diff.length > 5000) {
+const MAX_DIFF_CHAR_COUNT = 500000;
+
+function usage() {
+    console.log("node index.js MONGODB_ID < line_diff_contents.diff");
+}
+
+if(process.argv.length < 3) {
+    console.error("A MongoDB ID is required");
+    usage();
+    process.exit(2);
+}
+
+const mongoID = process.argv[2];
+const convertDiffAndUpdateMongo = async(function() {
+/* start async */
+
+let line_diff = await(getStdin());
+if(line_diff.length > MAX_DIFF_CHAR_COUNT) {
+    // Allow it to complete and generate no diff at all to simplify processing.
+    line_diff = "";
+}
+
+const word_diff = JsDiff.parsePatch(line_diff)
+    .map(diffLineToWord)
+    .join("\n");
+
+MongoClient.connect('mongodb://localhost:27017/github', function(err, db) {
+    if(err != null) {
+        console.error("Could not connect to MongoDB");
         process.exit(1);
     }
-    const patches = JsDiff.parsePatch(line_diff);
-    patches.map(diffLineToWord)
-        .forEach(function(patch) {
-            console.log(patch);
-        });
+
+    let collection = db.collection('events');
+    collection.updateOne({"_id": ObjectId(mongoID)}, { "$set": {"word_diff": word_diff}});
+    console.log("Successfully updated diff for ID: " + mongoID);
+
+    db.close();
 });
+
+/* end async */
+});
+
+convertDiffAndUpdateMongo();

--- a/data-scripts/line-to-word-diff/index.js
+++ b/data-scripts/line-to-word-diff/index.js
@@ -9,7 +9,7 @@ const mongodb = require('mongodb');
 const MongoClient = mongodb.MongoClient;
 const ObjectId = mongodb.ObjectId;
 
-const MAX_DIFF_CHAR_COUNT = 500000;
+const MAX_DIFF_CHAR_COUNT = 100000;
 
 function usage() {
     console.log("node index.js MONGODB_ID < line_diff_contents.diff");

--- a/data-scripts/line-to-word-diff/package.json
+++ b/data-scripts/line-to-word-diff/package.json
@@ -4,9 +4,11 @@
   "description": "Convert line diffs to word diffs",
   "main": "index.js",
   "dependencies": {
+    "asyncawait": "^1.0.6",
     "diff": "^2.2.1",
     "diff-linetoword": "^1.1.2",
-    "get-stdin": "^5.0.1"
+    "get-stdin": "^5.0.1",
+    "mongodb": "^2.2.11"
   },
   "devDependencies": {},
   "scripts": {

--- a/data-scripts/utils.sh
+++ b/data-scripts/utils.sh
@@ -8,3 +8,27 @@ function success() {
     echo -e "\033[32m$@\033[m" >&2
 }
 
+function rate_limit() {
+    local RATE_LIMIT=$1
+    local COMMAND=${@:2}
+    if [ -z "${RATE_LIMIT}" ]; then
+        error 'Please provide a number followed by a command'
+        return 2
+    fi
+    if [ -z "${COMMAND}" ]; then
+        error 'Please provide a command following the rate limit number'
+        return 2
+    fi
+    if ! [[ ${RATE_LIMIT} =~ ^-?[0-9]+$ ]]; then
+        error 'Rate limit (first argument) is not a number'
+        return 2
+    fi
+    joblist=($(jobs -p))
+    while (( ${#joblist[*]} >= "$RATE_LIMIT" )); do
+        sleep 1
+        joblist=($(jobs -p))
+    done
+    bash -c "${COMMAND}" &
+    return $?
+}
+


### PR DESCRIPTION
Adds the automatic conversion and reinsertion of the word diff into the same MongoDB object.

If the query is run multiple times it will only grab the URLs from events that have not been downloaded and converted to word diffs. If there are more than five hundred thousand characters in a diff, the script will just insert a `""` into the event object instead of trying to convert the whole diff.

This PR also adds multi-core processing to speed things up a little.